### PR TITLE
fix(translation): Add missing manifest entry for German language

### DIFF
--- a/module.json
+++ b/module.json
@@ -19,6 +19,11 @@
       "lang": "en",
       "name": "English",
       "path": "lang/en.json"
+    },
+    {
+      "lang": "de",
+      "name": "Deutsch",
+      "path": "lang/de.json"
     }
   ],
   "url": "https://github.com/sPOiDar/fvtt-module-hide-gm-rolls",


### PR DESCRIPTION
I hope this is how you wanted it, name should be as you described. 