### PR TITLE
Update hide_gm_rolls.js

### DIFF
--- a/modules/hide_gm_rolls.js
+++ b/modules/hide_gm_rolls.js
@@ -253,8 +253,8 @@ class HideGMRolls {
 		}
 	}
 
-	static mangleRoll(doc, options) {
-		if (game.settings.get('hide-gm-rolls', 'private-hidden-tokens') && (options.rollMode === 'publicroll' || options.rollMode === undefined)) {
+	static mangleRoll(doc, data) {
+		if (game.settings.get('hide-gm-rolls', 'private-hidden-tokens') && data.rollMode === undefined ) {
 			// Skip processing unless we're a GM
 			if (!game.user?.isGM) {
 				return;
@@ -284,8 +284,8 @@ Hooks.on('ready', () => {
 	HideGMRolls.ready();
 });
 
-Hooks.on('preCreateChatMessage', (doc, _data, options) => {
-	HideGMRolls.mangleRoll(doc, options)
+Hooks.on('preCreateChatMessage', (doc, _data) => {
+	HideGMRolls.mangleRoll(doc, _data)
 });
 
 Hooks.on('renderChatMessage', (app, html, msg) => {

--- a/modules/hide_gm_rolls.js
+++ b/modules/hide_gm_rolls.js
@@ -253,20 +253,24 @@ class HideGMRolls {
 		}
 	}
 
-	static mangleRoll(doc, data) {
-		if (game.settings.get('hide-gm-rolls', 'private-hidden-tokens') && data.rollMode === undefined ) {
+	static mangleRoll(doc, options) {
+		// Skip if there is a defined rollMode
+		if (game.settings.get('hide-gm-rolls', 'private-hidden-tokens') && options.rollMode === undefined) {
+			
 			// Skip processing unless we're a GM
 			if (!game.user?.isGM) {
 				return;
 			}
 
-			let tokenId;
+			let speaker;
 			if (isNewerVersion(game.version, "10")) {
-				tokenId = doc.speaker?.token;
+				speaker = doc.speaker;
 			} else {
-				tokenId = doc.data?.speaker?.token;
+				speaker = doc.data?.speaker;
 			}
-			if (tokenId) {
+			
+			// Skip if the chat message speaker is described as The GM rather than the token
+			if (speaker?.tokenId && speaker?.alias !== "The GM") {
 				const token = game.canvas.tokens.get(tokenId);
 				if (token?.document?.hidden) {
 					doc.applyRollMode('gmroll');
@@ -284,7 +288,7 @@ Hooks.on('ready', () => {
 	HideGMRolls.ready();
 });
 
-Hooks.on('preCreateChatMessage', (doc, _data) => {
+Hooks.on('preCreateChatMessage', (doc, _data, options) => {
 	HideGMRolls.mangleRoll(doc, _data)
 });
 

--- a/modules/hide_gm_rolls.js
+++ b/modules/hide_gm_rolls.js
@@ -270,8 +270,8 @@ class HideGMRolls {
 			}
 			
 			// Skip if the chat message speaker is described as The GM rather than the token
-			if (speaker?.tokenId && speaker?.alias !== "The GM") {
-				const token = game.canvas.tokens.get(tokenId);
+			if (speaker?.token && speaker?.alias !== "The GM") {
+				const token = game.canvas.tokens.get(speaker.token);
 				if (token?.document?.hidden) {
 					doc.applyRollMode('gmroll');
 				}


### PR DESCRIPTION
I'm still learning what is and isn't possible with this stuff.

Really what I was trying to solve for it seems is to hide the chat messages coming from a hidden token when there is no defined message destination or roll mode.

I still want specifically chosen roll modes to apply but for anything like the combat turn tracker that I cannot specify, it should hide if the token is hidden.