### PR TITLE
fix(compatibility): Bump compatibility to v12

### DIFF
--- a/module.json
+++ b/module.json
@@ -14,8 +14,7 @@
   "compatibleCoreVersion": "11",
   "compatibility": {
     "minimum": "0.6.5",
-    "verified": "11",
-    "maximum": 11
+    "verified": "12.328"
   },
   "esmodules": [
     "modules/hide_gm_rolls.js"


### PR DESCRIPTION
Fixes #43

Tested all basic module features with Foundry version 12.328 and found them to work without the need for any module changes. Bumped the verified compatibility entry in `module.json` accordingly.

I removed the maximum compatibility entry. This should let users use this module in future versions, even if it doesn't get updated. We'll just get a warning from Foundry that compatibility hasn't been verified, and we can proceed at our own risk.

Did not test interactions with other modules, since there appears to be at least one outstanding related issue, which this PR isn't intended to address.